### PR TITLE
Change the way of reading in JOBBERGATE_PATH

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -106,3 +106,6 @@ venv.bak/
 
 # mypy
 .mypy_cache/
+
+# idea
+.idea

--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,0 +1,2 @@
+# Default ignored files
+/workspace.xml

--- a/.idea/inspectionProfiles/profiles_settings.xml
+++ b/.idea/inspectionProfiles/profiles_settings.xml
@@ -1,0 +1,6 @@
+<component name="InspectionProjectProfileManager">
+  <settings>
+    <option name="USE_PROJECT_PROFILE" value="false" />
+    <version value="1.0" />
+  </settings>
+</component>

--- a/.idea/jobbergate.iml
+++ b/.idea/jobbergate.iml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="PYTHON_MODULE" version="4">
+  <component name="NewModuleRootManager">
+    <content url="file://$MODULE_DIR$" />
+    <orderEntry type="inheritedJdk" />
+    <orderEntry type="sourceFolder" forTests="false" />
+  </component>
+  <component name="PyDocumentationSettings">
+    <option name="format" value="PLAIN" />
+    <option name="myDocStringFormat" value="Plain" />
+  </component>
+  <component name="TemplatesService">
+    <option name="TEMPLATE_CONFIGURATION" value="Jinja2" />
+    <option name="TEMPLATE_FOLDERS">
+      <list>
+        <option value="$MODULE_DIR$/apps/test_find_application_with_mainflow/templates" />
+      </list>
+    </option>
+  </component>
+</module>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="JavaScriptSettings">
+    <option name="languageLevel" value="ES6" />
+  </component>
+  <component name="ProjectRootManager" version="2" project-jdk-name="Python 3.7" project-jdk-type="Python SDK" />
+</project>

--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectModuleManager">
+    <modules>
+      <module fileurl="file://$PROJECT_DIR$/.idea/jobbergate.iml" filepath="$PROJECT_DIR$/.idea/jobbergate.iml" />
+    </modules>
+  </component>
+</project>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="$PROJECT_DIR$" vcs="Git" />
+  </component>
+</project>

--- a/jobbergate/lib.py
+++ b/jobbergate/lib.py
@@ -18,6 +18,7 @@ if jobbergatepath == "./":
         jobbergatepath
     except NameError as err:
         print(err)
+        jobbergateconfig = {}
         sys.exit(1)
 elif os.path.isabs(jobbergatepath):
     try:

--- a/jobbergate/lib.py
+++ b/jobbergate/lib.py
@@ -16,7 +16,7 @@ jobbergatepath = os.getenv("JOBBERGATE_PATH", None)
 if jobbergatepath is None:
     print("Undefined JOBBERGATE_PATH")
     jobbergateconfig = {}
-    sys.exit(0)
+    sys.exit()
 
 if os.path.isabs(jobbergatepath):
     try:

--- a/jobbergate/lib.py
+++ b/jobbergate/lib.py
@@ -14,6 +14,7 @@ import yaml
 jobbergatepath = os.getenv("JOBBERGATE_PATH", None)
 
 if jobbergatepath is None:
+    jobbergateconfig = {}
     sys.exit(0)
 elif os.path.isabs(jobbergatepath):
     try:

--- a/jobbergate/lib.py
+++ b/jobbergate/lib.py
@@ -14,12 +14,7 @@ import yaml
 jobbergatepath = os.getenv("JOBBERGATE_PATH", "./")
 
 if jobbergatepath == "./":
-    try:
-        jobbergatepath
-    except NameError as err:
-        print(err)
-        jobbergateconfig = {}
-        sys.exit(1)
+    sys.exit(0)
 elif os.path.isabs(jobbergatepath):
     try:
         with open(f"{jobbergatepath}/jobbergate.yaml") as ymlfile:

--- a/jobbergate/lib.py
+++ b/jobbergate/lib.py
@@ -13,16 +13,24 @@ import yaml
 
 jobbergatepath = os.getenv("JOBBERGATE_PATH", "./")
 
-try:
-    with open(f"{jobbergatepath}/jobbergate.yaml") as ymlfile:
-        jobbergateconfig = yaml.safe_load(ymlfile)
-except FileNotFoundError as err:
-    if __name__ == "__main__":
+if os.path.isabs(jobbergatepath):
+    try:
+        with open(f"{jobbergatepath}/jobbergate.yaml") as ymlfile:
+            jobbergateconfig = yaml.safe_load(ymlfile)
+    except FileNotFoundError as err:
+        if __name__ == "__main__":
+            print(err)
+            sys.exit(1)
+        else:
+            jobbergateconfig = {}
+else:
+    try:
+        app = importlib.import_module(jobbergatepath)
+        path = os.path.join(os.path.dirname(app.__file__), "apps")
+        jobbergateconfig = {"apps":{"path":path}}
+    except ModuleNotFoundError as err:
         print(err)
         sys.exit(1)
-    else:
-        jobbergateconfig = {}
-
 
 def fullpath_import(path, lib):
     """Imports a file from absolute path.

--- a/jobbergate/lib.py
+++ b/jobbergate/lib.py
@@ -30,6 +30,7 @@ else:
         jobbergateconfig = {"apps": {"path": path}}
     except ModuleNotFoundError as err:
         print(err)
+        jobbergateconfig = {}
         sys.exit(1)
 
 

--- a/jobbergate/lib.py
+++ b/jobbergate/lib.py
@@ -13,7 +13,7 @@ import yaml
 
 jobbergatepath = os.getenv("JOBBERGATE_PATH", "./")
 
-if jobbergatepath is "./":
+if jobbergatepath == "./":
     print("Undefined JOBBERGATE_PATH")
     jobbergateconfig = {}
 elif os.path.isabs(jobbergatepath):

--- a/jobbergate/lib.py
+++ b/jobbergate/lib.py
@@ -11,11 +11,15 @@ import os
 import sys
 import yaml
 
+
+def quit_app():
+    return
+
 jobbergatepath = os.getenv("JOBBERGATE_PATH", None)
 
 if jobbergatepath is None:
     jobbergateconfig = {}
-    return
+    quit_app()
 elif os.path.isabs(jobbergatepath):
     try:
         with open(f"{jobbergatepath}/jobbergate.yaml") as ymlfile:

--- a/jobbergate/lib.py
+++ b/jobbergate/lib.py
@@ -15,7 +15,7 @@ jobbergatepath = os.getenv("JOBBERGATE_PATH", None)
 
 if jobbergatepath is None:
     jobbergateconfig = {}
-    raise SystemExit
+    return
 elif os.path.isabs(jobbergatepath):
     try:
         with open(f"{jobbergatepath}/jobbergate.yaml") as ymlfile:

--- a/jobbergate/lib.py
+++ b/jobbergate/lib.py
@@ -11,9 +11,9 @@ import os
 import sys
 import yaml
 
-jobbergatepath = os.getenv("JOBBERGATE_PATH", "./")
+jobbergatepath = os.getenv("JOBBERGATE_PATH", None)
 
-if jobbergatepath == "./":
+if jobbergatepath is None:
     sys.exit(0)
 elif os.path.isabs(jobbergatepath):
     try:

--- a/jobbergate/lib.py
+++ b/jobbergate/lib.py
@@ -13,6 +13,10 @@ import yaml
 
 jobbergatepath = os.getenv("JOBBERGATE_PATH", None)
 
+if jobbergatepath is None:
+    print("Undefined JOBBERGATE_PATH")
+    sys.exit(1)
+
 if os.path.isabs(jobbergatepath):
     try:
         with open(f"{jobbergatepath}/jobbergate.yaml") as ymlfile:

--- a/jobbergate/lib.py
+++ b/jobbergate/lib.py
@@ -13,12 +13,6 @@ import yaml
 
 jobbergatepath = os.getenv("JOBBERGATE_PATH", "./")
 
-try:
-    jobbergatepath
-except NameError:
-    print("Undefined JOBBERGATE_PATH")
-    sys.exit(1)  # JOBBERGATE_PATH does not exist at all
-
 if os.path.isabs(jobbergatepath):
     try:
         with open(f"{jobbergatepath}/jobbergate.yaml") as ymlfile:
@@ -31,7 +25,7 @@ if os.path.isabs(jobbergatepath):
             jobbergateconfig = {}
 else:
     try:
-        app = importlib.import_module(jobbergatepath)
+        app = importlib.import_module(jobbergatepath, package=None)
         path = os.path.join(os.path.dirname(app.__file__), "apps")
         jobbergateconfig = {"apps": {"path": path}}
     except ModuleNotFoundError as err:

--- a/jobbergate/lib.py
+++ b/jobbergate/lib.py
@@ -15,7 +15,7 @@ jobbergatepath = os.getenv("JOBBERGATE_PATH", None)
 
 if jobbergatepath is None:
     print("Undefined JOBBERGATE_PATH")
-    sys.exit(1)
+    sys.exit(0)
 
 if os.path.isabs(jobbergatepath):
     try:

--- a/jobbergate/lib.py
+++ b/jobbergate/lib.py
@@ -15,7 +15,7 @@ jobbergatepath = os.getenv("JOBBERGATE_PATH", None)
 
 if jobbergatepath is None:
     jobbergateconfig = {}
-    sys.exit(0)
+    raise SystemExit
 elif os.path.isabs(jobbergatepath):
     try:
         with open(f"{jobbergatepath}/jobbergate.yaml") as ymlfile:

--- a/jobbergate/lib.py
+++ b/jobbergate/lib.py
@@ -11,9 +11,9 @@ import os
 import sys
 import yaml
 
-jobbergatepath = os.getenv("JOBBERGATE_PATH", None)
+jobbergatepath = os.getenv("JOBBERGATE_PATH", "./")
 
-if jobbergatepath is None:
+if jobbergatepath is "./":
     print("Undefined JOBBERGATE_PATH")
     jobbergateconfig = {}
 elif os.path.isabs(jobbergatepath):

--- a/jobbergate/lib.py
+++ b/jobbergate/lib.py
@@ -13,6 +13,12 @@ import yaml
 
 jobbergatepath = os.getenv("JOBBERGATE_PATH", "./")
 
+try:
+    jobbergatepath
+except NameError:
+    print("Undefined JOBBERGATE_PATH")
+    sys.exit(1)  # JOBBERGATE_PATH does not exist at all
+
 if os.path.isabs(jobbergatepath):
     try:
         with open(f"{jobbergatepath}/jobbergate.yaml") as ymlfile:
@@ -23,9 +29,6 @@ if os.path.isabs(jobbergatepath):
             sys.exit(1)
         else:
             jobbergateconfig = {}
-elif jobbergatepath is None:
-    print("Undefined JOBBERGATE_PATH")
-    sys.exit(1)
 else:
     try:
         app = importlib.import_module(jobbergatepath)

--- a/jobbergate/lib.py
+++ b/jobbergate/lib.py
@@ -27,14 +27,14 @@ else:
     try:
         app = importlib.import_module(jobbergatepath)
         path = os.path.join(os.path.dirname(app.__file__), "apps")
-        jobbergateconfig = {"apps":{"path":path}}
+        jobbergateconfig = {"apps": {"path": path}}
     except ModuleNotFoundError as err:
         print(err)
         sys.exit(1)
 
+
 def fullpath_import(path, lib):
     """Imports a file from absolute path.
-
     :param path: full path to lib
     :param lib: lib to import
     """

--- a/jobbergate/lib.py
+++ b/jobbergate/lib.py
@@ -16,7 +16,7 @@ jobbergatepath = os.getenv("JOBBERGATE_PATH", None)
 if jobbergatepath is None:
     print("Undefined JOBBERGATE_PATH")
     jobbergateconfig = {}
-    sys.exit()
+    exit(0)
 
 if os.path.isabs(jobbergatepath):
     try:

--- a/jobbergate/lib.py
+++ b/jobbergate/lib.py
@@ -23,6 +23,9 @@ if os.path.isabs(jobbergatepath):
             sys.exit(1)
         else:
             jobbergateconfig = {}
+elif jobbergatepath is None:
+    print("Undefined JOBBERGATE_PATH")
+    sys.exit(1)
 else:
     try:
         app = importlib.import_module(jobbergatepath)

--- a/jobbergate/lib.py
+++ b/jobbergate/lib.py
@@ -14,8 +14,11 @@ import yaml
 jobbergatepath = os.getenv("JOBBERGATE_PATH", "./")
 
 if jobbergatepath == "./":
-    print("Undefined JOBBERGATE_PATH")
-    jobbergateconfig = {}
+    try:
+        jobbergatepath
+    except NameError as err:
+        print(err)
+        sys.exit(1)
 elif os.path.isabs(jobbergatepath):
     try:
         with open(f"{jobbergatepath}/jobbergate.yaml") as ymlfile:

--- a/jobbergate/lib.py
+++ b/jobbergate/lib.py
@@ -15,6 +15,7 @@ import yaml
 def quit_app():
     return
 
+
 jobbergatepath = os.getenv("JOBBERGATE_PATH", None)
 
 if jobbergatepath is None:

--- a/jobbergate/lib.py
+++ b/jobbergate/lib.py
@@ -15,6 +15,7 @@ jobbergatepath = os.getenv("JOBBERGATE_PATH", None)
 
 if jobbergatepath is None:
     print("Undefined JOBBERGATE_PATH")
+    jobbergateconfig = {}
     sys.exit(0)
 
 if os.path.isabs(jobbergatepath):

--- a/jobbergate/lib.py
+++ b/jobbergate/lib.py
@@ -16,9 +16,7 @@ jobbergatepath = os.getenv("JOBBERGATE_PATH", None)
 if jobbergatepath is None:
     print("Undefined JOBBERGATE_PATH")
     jobbergateconfig = {}
-    exit(0)
-
-if os.path.isabs(jobbergatepath):
+elif os.path.isabs(jobbergatepath):
     try:
         with open(f"{jobbergatepath}/jobbergate.yaml") as ymlfile:
             jobbergateconfig = yaml.safe_load(ymlfile)

--- a/jobbergate/lib.py
+++ b/jobbergate/lib.py
@@ -11,7 +11,7 @@ import os
 import sys
 import yaml
 
-jobbergatepath = os.getenv("JOBBERGATE_PATH", "./")
+jobbergatepath = os.getenv("JOBBERGATE_PATH", None)
 
 if os.path.isabs(jobbergatepath):
     try:


### PR DESCRIPTION
We define JOBBERGATE_PATH the same as module name in our own app and read in the absolute path of installed artifactory of our app in lib.py of Jobbergate framework, to avoid reading the absolute path in jobbergate.yaml, which is not able to be edited during pip installation.