### PR TITLE
Add functon to read jobbergate_path as both an directory path and a m…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -106,3 +106,6 @@ venv.bak/
 
 # mypy
 .mypy_cache/
+
+# idea
+.idea

--- a/jobbergate/lib.py
+++ b/jobbergate/lib.py
@@ -36,6 +36,7 @@ else:
 
 def fullpath_import(path, lib):
     """Imports a file from absolute path.
+
     :param path: full path to lib
     :param lib: lib to import
     """

--- a/jobbergate/lib.py
+++ b/jobbergate/lib.py
@@ -13,20 +13,29 @@ import yaml
 
 jobbergatepath = os.getenv("JOBBERGATE_PATH", "./")
 
-try:
-    with open(f"{jobbergatepath}/jobbergate.yaml") as ymlfile:
-        jobbergateconfig = yaml.safe_load(ymlfile)
-except FileNotFoundError as err:
-    if __name__ == "__main__":
+if os.path.isdir(jobbergatepath):
+    try:
+        with open(f"{jobbergatepath}/jobbergate.yaml") as ymlfile:
+            jobbergateconfig = yaml.safe_load(ymlfile)
+    except FileNotFoundError as err:
+        if __name__ == "__main__":
+            print(err)
+            sys.exit(1)
+        else:
+            jobbergateconfig = {}
+else:
+    try:
+        app = importlib.import_module(jobbergatepath, package=None)
+        path = os.path.join(os.path.dirname(app.__file__), "apps")
+        jobbergateconfig = {"apps": {"path": path}}
+    except ModuleNotFoundError as err:
         print(err)
-        sys.exit(1)
-    else:
         jobbergateconfig = {}
+        sys.exit(1)
 
 
 def fullpath_import(path, lib):
     """Imports a file from absolute path.
-
     :param path: full path to lib
     :param lib: lib to import
     """


### PR DESCRIPTION
…odule name.

User can define JOBBERGATE_PATH in his application as a module name.
The Jobbergate's lib.py checks if the JOBBERGATE_PATH is an absolute/relative directory path or a module name, and takes respective measures to read in the JOBBERGATE_PATH.