### PR TITLE
Optional cmd skip

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -56,6 +56,6 @@ the application will run::
     cat outputfile.sh
 
 which shows the content of the output file.
-This feature can be supressed by using the '--no-cmd' flag::
+This feature can be suppressed by using the '--no-cmd' flag::
 
     flask simple outputfile.sh --no-cmd

--- a/README.rst
+++ b/README.rst
@@ -56,3 +56,6 @@ the application will run::
     cat outputfile.sh
 
 which shows the content of the output file.
+This feature can be supressed by using the '--no-cmd' flag::
+
+    flask simple outputfile.sh --no-cmd

--- a/jobbergate/cli.py
+++ b/jobbergate/cli.py
@@ -367,7 +367,7 @@ def app_factory():
             jinjatemplate = jinjaenv.get_template(template)
             file = outputfile.write(jinjatemplate.render(data=data))
             outputfile.flush()
-            if "cmd_command" in data.keys():
+            if "cmd_command" in data.keys() and not kvargs["no_cmd"]:
                 subprocess.run(data["cmd_command"], shell=True)
             return file
 
@@ -401,6 +401,12 @@ def app_factory():
         click.Option(
             param_decls=("-f", "--fast"),
             help="Fast-forward by using defaults instead of asking when possible.",
+            required=False,
+            is_flag=True,
+        ),
+        click.Option(
+            param_decls=["--no-cmd"],
+            help="Disables performing the instructions in the application's 'cmd-command', if any",
             required=False,
             is_flag=True,
         ),


### PR DESCRIPTION
Adding option to skip performing the bash code that may or may not be defined in the 'cmd_command' field.

Open to suggestions for other name for the option. (now: --no-cmd)